### PR TITLE
feature/fixing_the_prompt_and_add_function_that_delete_yesterday_matches

### DIFF
--- a/src/controllers/prediction_controller.ts
+++ b/src/controllers/prediction_controller.ts
@@ -1,4 +1,4 @@
-import { generatePrediction, createPromptForMatches } from '../services/predictionService';
+import { generatePrediction, createPromptForMatches, deleteAllPredictions } from '../services/predictionService';
 import predictionModel from '../models/predictionModel';
 import postModel from '../models/postModel';
 import cron from 'node-cron';
@@ -16,11 +16,14 @@ export const getAllPredictions = async (req: any, res: any) => {
 // Function to create predictions automatically
 export const createPredictionsAutomatically = async () => {
   try {
+
+    const response = await deleteAllPredictions();
     // Create a prompt for the upcoming matches
     const prompt = await createPromptForMatches();
 
     // Generate predictions based on the prompt
     let gptResponseString = await generatePrediction(prompt);
+    console.log('Prediction received:', gptResponseString);
     gptResponseString = gptResponseString.trim()
     .replace(/^```json\s*\n|\n```$/g, '');
     const gptResponse = JSON.parse(gptResponseString);
@@ -79,7 +82,7 @@ export const createPostByPrediction = async (req: any, res: any) => {
 
 
 // Create predictions automatically every day at 6:00 AM
-cron.schedule('0 6 * * *', async () => {
+cron.schedule('* * * * *', async () => {
   try {
     const prompt = await createPredictionsAutomatically();
     console.log("Generated prompt for matches:", prompt);

--- a/src/services/predictionService.ts
+++ b/src/services/predictionService.ts
@@ -1,5 +1,7 @@
 import OpenAI from 'openai';
 import axios from 'axios';
+import exp from 'constants';
+import predictionModel from '../models/predictionModel';
 
 
 
@@ -39,6 +41,19 @@ export const generatePrediction = async (prompt: string): Promise<string> => {
     throw error;
   }
 };
+
+export const deleteAllPredictions = async () => {
+  try {
+    // Delete all predictions from the database
+    await predictionModel.deleteMany();
+    console.log("Yesterday predictions deleted successfully");
+    return;
+  } catch (error) {
+    console.error("Error deleting predictions:", error);
+    throw error;
+  }
+}
+
 
 
 interface Team {
@@ -105,6 +120,8 @@ export const createPromptForMatches = async (): Promise<string> => {
 
     // Create a prompt for the upcoming matches
     const prompt = `You are a football match prediction expert. Based on your analysis of recent team performance, historical data, and current form, provide predictions for the following matches in a precise JSON format.
+    Please return only the JSON object without any additional text, disclaimers etc.
+
 
     Rules for predictions:
     1. Scores should be realistic (typically 0-5 goals per team)


### PR DESCRIPTION
Fixing the prediction generator by changing to prompt in order to clean AI's answer. Adding delete function that will remove yesterday's matches from the db and by that from the prediction page